### PR TITLE
Hotfix regression webhook 

### DIFF
--- a/__tests__/unit/explorer.test.js
+++ b/__tests__/unit/explorer.test.js
@@ -8,7 +8,7 @@ test("Ensure that a testnet explorer url returns", () => {
 
   const url = Explorer.getExplorerUrl(placeholderTx)
 
-	expect(url.explorer_url).toBe(`https://ledger-testnet.hashlog.io/tx/${placeholderTx}`)
+	expect(url).toBe(`https://ledger-testnet.hashlog.io/tx/${placeholderTx}`)
 })
 
 test("Ensure that a mainnet explorer url returns", () => {
@@ -16,7 +16,7 @@ test("Ensure that a mainnet explorer url returns", () => {
 
   const url = Explorer.getExplorerUrl(placeholderTx)
 
-  expect(url.explorer_url).toBe(`https://ledger.hashlog.io/tx/${placeholderTx}`)
+  expect(url).toBe(`https://ledger.hashlog.io/tx/${placeholderTx}`)
 })
 
 test("Ensure that a previewnet explorer url returns nothing", () => {
@@ -24,5 +24,5 @@ test("Ensure that a previewnet explorer url returns nothing", () => {
 
   const url = Explorer.getExplorerUrl(placeholderTx)
 
-	expect(!url.explorer_url)
+	expect(!url)
 })

--- a/app/utils/explorer.js
+++ b/app/utils/explorer.js
@@ -10,8 +10,8 @@ const ExplorerUrl = {
 function getExplorerUrl(tx) {
 	const network = Config.HEDERA_NETWORK || Environment.TESTNET
 
-	return {
-		explorer_url: ExplorerUrl[network] + tx
+	if (network) {
+		return ExplorerUrl[network] + tx
 	}
 }
 


### PR DESCRIPTION
# Rationale

From the migration of the Hedera JS SDK to v2 there were some regression issues with the webhook functionality.

# Resolution

Updated the client and explorer util so the Laravel library can handle it still.

# Work to be done

We need to use a mirror node service for querying transactions when we get more traffic.

Ideally, we need a NodeJS service, that isn't serverless, to be more webhook and serverless friendly