### PR TITLE
[Hotfix] - Catch accounts currently associated

### DIFF
--- a/__tests__/e2e/hashgraph_client.test.js
+++ b/__tests__/e2e/hashgraph_client.test.js
@@ -162,6 +162,14 @@ test("The client can bequest an account with tokens", async () => {
 	expect(bequest.amount).toBeDefined()
 	expect(bequest.receiver_id).toBeDefined()
 	expect(bequest.transaction_id).toBeDefined()
+
+	// Send more tokens, as a user is associated, catch the issue.
+	await client.bequestToken({
+		encrypted_receiver_key: account.encryptedKey,
+		token_id: token.tokenId,
+		receiver_id: account.accountId,
+		amount: 1
+	})
 }, 20000)
 
 // Venly test

--- a/app/hashgraph/client.js
+++ b/app/hashgraph/client.js
@@ -175,8 +175,12 @@ class HashgraphClient extends HashgraphClientContract {
 		const signTx = await transaction.sign(accountPrivateKey)
 		const executeTx = await signTx.execute(client)
 
-		// Wait to finish for consensus
-		await executeTx.getReceipt(client)
+		// Wait to finish for consensus and catch if association has already happened
+		try {
+			await executeTx.getReceipt(client)
+		} catch (_) {
+			console.warn(`Account: ${accountId} already associated to token - ${tokenIds}` )
+		}
 
 		return executeTx
 	}

--- a/app/hashgraph/client.js
+++ b/app/hashgraph/client.js
@@ -179,7 +179,9 @@ class HashgraphClient extends HashgraphClientContract {
 		try {
 			await executeTx.getReceipt(client)
 		} catch (_) {
-			console.warn(`Account: ${accountId} already associated to token - ${tokenIds}` )
+			console.warn(
+				`Account: ${accountId} already associated to token - ${tokenIds}`
+			)
 		}
 
 		return executeTx


### PR DESCRIPTION
## Overview

For all transactions all receipt confirmation should be synchronous if there are other SDK that rely on the state of the Hedera network, this includes token association.

For the bequesting of tokens where a user may purchase many times from a single project there is a need to check association, we do this by sending an assoc request, which may be overkill for every permission transfer call in a given system but it provides the simplest route.

We are catching any errors and printing that may come from an account with a current assoc to a token.