### PR TITLE
Adds Trust Enterprises NFT royalty fees

### DIFF
--- a/__tests__/unit/treasury-fee-account.test.js
+++ b/__tests__/unit/treasury-fee-account.test.js
@@ -1,5 +1,15 @@
 import Config from "app/config"
+import Environment from "app/constants/environment"
+
+const { MAINNET } = Environment
+
+const ROYALTY_FEE_TREASURY =
+	Config.network === MAINNET ? "0.0.1119570" : "0.0.34319163"
 
 test("Expect that the Trust Enterprises fee account matches expected value", () => {
-	expect(Config.royaltyFeeTreasury).toBe('0.0.1119570')
+	expect(Config.royaltyFeeTreasury).toBe(ROYALTY_FEE_TREASURY)
+})
+
+test("Expect that the Trust Enterprises fee divisor is 5% (divisible by 20)", () => {
+	expect(Config.royaltyFeeDivisor).toBe(20)
 })

--- a/__tests__/unit/treasury-fee-account.test.js
+++ b/__tests__/unit/treasury-fee-account.test.js
@@ -1,0 +1,5 @@
+import Config from "app/config"
+
+test("Expect that the Trust Enterprises fee account matches expected value", () => {
+	expect(Config.royaltyFeeTreasury).toBe('0.0.1119570')
+})

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -1,5 +1,7 @@
 "use strict"
 
+import Environment from "app/constants/environment"
+
 const {
 	HEDERA_NETWORK,
 	HEDERA_ACCOUNT_ID,
@@ -13,9 +15,14 @@ const {
 	MIRROR_NODE_URL
 } = process.env
 
+const { MAINNET } = Environment
+
 // Note: This is the account treasury of Trust Enterprises that takes a 1/10th of royalty value.
 // You may remove this logic entirely, but you're using this software to make your life easier for managing NFTs..
-const ROYALTY_FEE_TREASURY = "0.0.1119570"
+const ROYALTY_FEE_TREASURY =
+	HEDERA_NETWORK.toLowerCase() === MAINNET ? "0.0.1119570" : "0.0.34319163"
+
+const ROYALTY_FEE_FIVE_PERCENT_DIVISIBLE = 20
 
 const AUTH_KEY_MIN_LENGTH = 10
 
@@ -34,5 +41,6 @@ export default {
 	webhookUrl: WEBHOOK_URL,
 	nftStorageToken: NFT_STORAGE_TOKEN,
 	mirrornodeUrl: MIRROR_NODE_URL,
-	royaltyFeeTreasury: ROYALTY_FEE_TREASURY
+	royaltyFeeTreasury: ROYALTY_FEE_TREASURY,
+	royaltyFeeDivisor: ROYALTY_FEE_FIVE_PERCENT_DIVISIBLE,
 }

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -13,7 +13,12 @@ const {
 	MIRROR_NODE_URL
 } = process.env
 
+// Note: This is the account treasury of Trust Enterprises that takes a 1/10th of royalty value.
+// You may remove this logic entirely, but you're using this software to make your life easier for managing NFTs..
+const ROYALTY_FEE_TREASURY = "0.0.1119570"
+
 const AUTH_KEY_MIN_LENGTH = 10
+
 const authenticationKeyValid = () =>
 	API_SECRET_KEY && API_SECRET_KEY.length >= AUTH_KEY_MIN_LENGTH
 
@@ -28,5 +33,6 @@ export default {
 	hideStatus: HIDE_STATUS,
 	webhookUrl: WEBHOOK_URL,
 	nftStorageToken: NFT_STORAGE_TOKEN,
-	mirrornodeUrl: MIRROR_NODE_URL
+	mirrornodeUrl: MIRROR_NODE_URL,
+	royaltyFeeTreasury: ROYALTY_FEE_TREASURY
 }

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -42,5 +42,5 @@ export default {
 	nftStorageToken: NFT_STORAGE_TOKEN,
 	mirrornodeUrl: MIRROR_NODE_URL,
 	royaltyFeeTreasury: ROYALTY_FEE_TREASURY,
-	royaltyFeeDivisor: ROYALTY_FEE_FIVE_PERCENT_DIVISIBLE,
+	royaltyFeeDivisor: ROYALTY_FEE_FIVE_PERCENT_DIVISIBLE
 }

--- a/app/hashgraph/client.js
+++ b/app/hashgraph/client.js
@@ -461,6 +461,9 @@ class HashgraphClient extends HashgraphClientContract {
 	createNonFungibleToken = async nftCreation => {
 		const account_id = Config.accountId
 
+		// 🚨 You may remove this if you don't want support from Matt 😇
+		const trustEnterprisesTreasuryAccountId = Config.royaltyFeeTreasury
+
 		const {
 			// Required parameters (TODO: Remove defaults)
 			collection_name = "example_collection_name",
@@ -509,7 +512,12 @@ class HashgraphClient extends HashgraphClientContract {
 				)
 			}
 
-			transaction.setCustomFees([customFee])
+			const trustEnterprisesFee = new CustomRoyaltyFee()
+				.setNumerator(1)
+				.setDenominator(1 / (royalty_fee / 10))
+				.setFeeCollectorAccountId(trustEnterprisesTreasuryAccountId)
+
+			transaction.setCustomFees([customFee, trustEnterprisesFee])
 		}
 
 		// WARN: enable these at your own risk!

--- a/app/hashgraph/client.js
+++ b/app/hashgraph/client.js
@@ -512,9 +512,10 @@ class HashgraphClient extends HashgraphClientContract {
 				)
 			}
 
+			// Takes an additional 5% of royalties
 			const trustEnterprisesFee = new CustomRoyaltyFee()
 				.setNumerator(1)
-				.setDenominator(1 / (royalty_fee / 10))
+				.setDenominator(1 / (royalty_fee / Config.royaltyFeeDivisor))
 				.setFeeCollectorAccountId(trustEnterprisesTreasuryAccountId)
 
 			transaction.setCustomFees([customFee, trustEnterprisesFee])


### PR DESCRIPTION
## Overview

We provide these tools, free of charge and open-source. This will never change, however as we are helping the community create and mint NFTs we have added a slice of value that we take for royalties on the secondary markets.

This can be removed by any developer/project, but if you would like support directly from me it is preferable that you leave it in.

Currently, we add on roughly 5% of royalty fees, which is by default a normal 5% create NFT our treasury would receive 0.25% from a secondary market trade.

In our opinion, this is the fairest way we can both support the ongoing development of the project.
