### PR TITLE
Added creatorDid and attributes fields (HIP412 validation)

### DIFF
--- a/app/validators/createMetadataRequest.js
+++ b/app/validators/createMetadataRequest.js
@@ -16,6 +16,8 @@ const schema = Joi.object()
 
 		creator: Joi.string().optional(),
 
+		creatorDid: Joi.string().optional(),
+
 		description: Joi.string().optional(),
 
 		image: Joi.string().optional(),
@@ -36,6 +38,10 @@ const schema = Joi.object()
 					metadata_uri: Joi.string().required()
 				})
 				.optional()
+		),
+
+		attributes: Joi.array().items(
+			Joi.object().optional()
 		),
 
 		// Properties seems like a free-for-all 😂

--- a/app/validators/createMetadataRequest.js
+++ b/app/validators/createMetadataRequest.js
@@ -40,9 +40,7 @@ const schema = Joi.object()
 				.optional()
 		),
 
-		attributes: Joi.array().items(
-			Joi.object().optional()
-		),
+		attributes: Joi.array().items(Joi.object().optional()),
 
 		// Properties seems like a free-for-all 😂
 		properties: Joi.object()


### PR DESCRIPTION
## Overview

This added 2 additional [HIP412](https://hips.hedera.com/hip/hip-412) to metadata validation:

- creatorDid
- attributes

The **creatorDid** is supposed to be a chain agnostic decentralized identifier, we don't validate the format of the DID.

The **attributes** field is akin to opensea NFT standards, an array of objects (you may add whatever details you want)

## Notes 

Both of these fields are hidden in the spec and not part of the **Formal JSON Schema Definition** of the HIP 🙃