### PR TITLE
Token decimal processing

### DIFF
--- a/__tests__/e2e/hashgraph_client.test.js
+++ b/__tests__/e2e/hashgraph_client.test.js
@@ -1,6 +1,5 @@
 import HashgraphClient from "app/hashgraph/client"
 import sleep from "app/utils/sleep"
-import balance from "../../pages/api/account/balance"
 
 const client = new HashgraphClient()
 
@@ -244,5 +243,45 @@ test("This test will check if a wallet holds different tokens", async () => {
 	})
 
 	expect(hasTokensTrue.has_tokens).toBeTruthy()
+
+}, 20000)
+
+
+test("This test will create a token with explicit decimals", async () => {
+
+	const decimals = 2;
+
+	const tokenData = {
+		supply: "10",
+		name: 'example decimal token',
+		symbol: 'ted-e2e',
+		memo: 'DECIMAL TOKEN ACCOUNT TEST',
+		decimals
+	}
+
+	const token = await client.createToken(tokenData)
+
+	const account = await client.createAccount({
+		hasAutomaticAssociations: false
+	})
+
+	await client.bequestToken({
+		encrypted_receiver_key: account.encryptedKey,
+		token_id: token.tokenId,
+		receiver_id: account.accountId,
+		amount: 1,
+		decimals
+	})
+
+	// MUST AWAIT CONSENSUS 🙃
+	await sleep(5000)
+
+	const initialBalance = await client.getTokenBalance({
+		account_id: account.accountId,
+		token_id: token.tokenId,
+		decimals
+	})
+
+	expect(initialBalance.amount).toBe(1)
 
 }, 20000)

--- a/__tests__/e2e/nft_hashgraph.test.js
+++ b/__tests__/e2e/nft_hashgraph.test.js
@@ -94,7 +94,9 @@ test("This test will mint tokens for the NFT project", async () => {
 // Normally this would hit an end point for an integration test
 test("This will create an account and attempt to claim a token this will fail due to lack of association", async () => {
 
-	dummyAccount = await client.createAccount()
+	dummyAccount = await client.createAccount({
+		hasAutomaticAssociations: false
+	})
 
 	const claimable = await claimableTokenCheck({
 		token_id: nftProject.token_id,
@@ -147,7 +149,7 @@ test("After pass has been transferred a the same pass will be attempted to be se
 		serial_number: SERIAL_NUM
 	})
 
-	expect(transfer.error).toBe(`The treasury does not hold the token ${nftPass.token_id} of serial ${SERIAL_NUM}`)
+	expect(transfer.error[0]).toBe(`The treasury does not hold the token ${nftPass.token_id} of serial ${SERIAL_NUM}`)
 }, 20000)
 
 
@@ -160,7 +162,7 @@ test("After pass has been transferred a claim will be attempted again", async ()
 	})
 
 	expect(transfer.token_id).toBe(nftProject.token_id)
-	expect(transfer.error).toBe('Transfer failed, ensure that the recipient account is valid and has associated to the token')
+	expect(transfer.error[0]).toBe('Transfer failed, ensure that the recipient account is valid and has associated to the token')
 }, 20000)
 
 

--- a/app/handler/bequestTokenHandler.js
+++ b/app/handler/bequestTokenHandler.js
@@ -8,7 +8,13 @@ async function BequestTokenHandler(req, res) {
 		return Response.unprocessibleEntity(res, validationErrors)
 	}
 
-	const { encrypted_receiver_key, token_id, receiver_id, amount, decimals } = req.body
+	const {
+		encrypted_receiver_key,
+		token_id,
+		receiver_id,
+		amount,
+		decimals
+	} = req.body
 
 	const bequestPayload = {
 		encrypted_receiver_key,

--- a/app/handler/bequestTokenHandler.js
+++ b/app/handler/bequestTokenHandler.js
@@ -8,12 +8,14 @@ async function BequestTokenHandler(req, res) {
 		return Response.unprocessibleEntity(res, validationErrors)
 	}
 
-	const { encrypted_receiver_key, token_id, receiver_id, amount } = req.body
+	const { encrypted_receiver_key, token_id, receiver_id, amount, decimals } = req.body
+
 	const bequestPayload = {
 		encrypted_receiver_key,
 		token_id,
 		receiver_id,
-		amount
+		amount,
+		decimals
 	}
 
 	const { hashgraphClient } = req.context

--- a/app/handler/checkBalanceTokenHandler.js
+++ b/app/handler/checkBalanceTokenHandler.js
@@ -1,11 +1,12 @@
 import Response from "app/response"
 
 async function CheckBalanceTokenHandler(req, res) {
-	const { id, token_id } = req.query
+	const { id, token_id, decimals } = req.query
 
 	const balancePayload = {
 		account_id: id,
-		token_id
+		token_id,
+		decimals
 	}
 
 	const { hashgraphClient } = req.context

--- a/app/handler/createTokenHandler.js
+++ b/app/handler/createTokenHandler.js
@@ -15,7 +15,8 @@ async function CreateTokenHandler(req, res) {
 		supply,
 		memo,
 		requires_kyc = false,
-		can_freeze = false
+		can_freeze = false,
+		decimals
 	} = req.body
 
 	const { hashgraphClient } = req.context
@@ -27,7 +28,8 @@ async function CreateTokenHandler(req, res) {
 		symbol,
 		supply,
 		requires_kyc,
-		can_freeze
+		can_freeze,
+		decimals
 	})
 
 	Response.json(res, token)

--- a/app/handler/sendTokenHandler.js
+++ b/app/handler/sendTokenHandler.js
@@ -8,12 +8,13 @@ async function SendTokenHandler(req, res) {
 		return Response.unprocessibleEntity(res, validationErrors)
 	}
 
-	const { receiver_id, token_id, amount } = req.body
+	const { receiver_id, token_id, amount, decimals } = req.body
 
 	const sendPayload = {
 		receiver_id,
 		token_id,
-		amount
+		amount,
+		decimals
 	}
 
 	const { hashgraphClient } = req.context

--- a/app/hashgraph/client.js
+++ b/app/hashgraph/client.js
@@ -226,7 +226,10 @@ class HashgraphClient extends HashgraphClientContract {
 			.execute(client)
 
 		// Token decimal pass through
-		const tokenDecimals = this.ensureDecimalsForClientCall(specification, decimals)
+		const tokenDecimals = this.ensureDecimalsForClientCall(
+			specification,
+			decimals
+		)
 
 		const token = JSON.parse(tokens.toString())[token_id]
 		const adjustedAmountBySpec = amount * 10 ** tokenDecimals
@@ -248,9 +251,7 @@ class HashgraphClient extends HashgraphClientContract {
 		}
 	}
 
-	createAccount = async ({
-		hasAutomaticAssociations = true
-	} = {}) => {
+	createAccount = async ({ hasAutomaticAssociations = true } = {}) => {
 		const privateKey = await PrivateKey.generate()
 		const publicKey = privateKey.publicKey
 		const client = this.#client
@@ -288,7 +289,10 @@ class HashgraphClient extends HashgraphClientContract {
 		const token = JSON.parse(tokens.toString())[token_id]
 
 		// Token decimal pass through
-		const tokenDecimals = this.ensureDecimalsForClientCall(specification, decimals)
+		const tokenDecimals = this.ensureDecimalsForClientCall(
+			specification,
+			decimals
+		)
 
 		const expectedValue = token / 10 ** tokenDecimals
 
@@ -332,7 +336,10 @@ class HashgraphClient extends HashgraphClientContract {
 			.execute(client)
 
 		// Token decimal pass through
-		const tokenDecimals = this.ensureDecimalsForClientCall(specification, decimals)
+		const tokenDecimals = this.ensureDecimalsForClientCall(
+			specification,
+			decimals
+		)
 
 		const token = JSON.parse(tokens.toString())[token_id]
 		const adjustedAmountBySpec = amount * 10 ** tokenDecimals
@@ -376,7 +383,10 @@ class HashgraphClient extends HashgraphClientContract {
 		const operatorPrivateKey = PrivateKey.fromString(Config.privateKey)
 
 		// Token decimal pass through
-		const tokenDecimals = this.ensureDecimalsForClientCall(specification, decimals)
+		const tokenDecimals = this.ensureDecimalsForClientCall(
+			specification,
+			decimals
+		)
 
 		const adjustedAmountBySpec = amount * 10 ** tokenDecimals
 
@@ -408,7 +418,10 @@ class HashgraphClient extends HashgraphClientContract {
 		const operatorPrivateKey = PrivateKey.fromString(Config.privateKey)
 
 		// Token decimal pass through
-		const tokenDecimals = this.ensureDecimalsForClientCall(specification, decimals)
+		const tokenDecimals = this.ensureDecimalsForClientCall(
+			specification,
+			decimals
+		)
 
 		const adjustedAmountBySpec = amount * 10 ** tokenDecimals
 
@@ -448,7 +461,10 @@ class HashgraphClient extends HashgraphClientContract {
 		const supplyPrivateKey = PrivateKey.fromString(Config.privateKey)
 
 		// Token decimal pass through
-		const tokenDecimals = this.ensureDecimalsForClientCall(specification, decimals)
+		const tokenDecimals = this.ensureDecimalsForClientCall(
+			specification,
+			decimals
+		)
 
 		const supplyWithDecimals = supply * 10 ** tokenDecimals
 

--- a/app/validators/bequestTokenRequest.js
+++ b/app/validators/bequestTokenRequest.js
@@ -7,7 +7,9 @@ const schema = Joi.object({
 	token_id: Joi.string().required(),
 	receiver_id: Joi.string().required(),
 	amount: Joi.number().required(),
-	decimals: Joi.number().min(1).optional()
+	decimals: Joi.number()
+		.min(1)
+		.optional()
 })
 
 function bequestTokenRequest(candidate = {}) {

--- a/app/validators/bequestTokenRequest.js
+++ b/app/validators/bequestTokenRequest.js
@@ -6,7 +6,8 @@ const schema = Joi.object({
 		.required(),
 	token_id: Joi.string().required(),
 	receiver_id: Joi.string().required(),
-	amount: Joi.number().required()
+	amount: Joi.number().required(),
+	decimals: Joi.number().min(1).optional()
 })
 
 function bequestTokenRequest(candidate = {}) {

--- a/app/validators/createTokenRequest.js
+++ b/app/validators/createTokenRequest.js
@@ -19,7 +19,9 @@ const schema = Joi.object({
 		.required(),
 	requires_kyc: Joi.bool().default(false),
 	can_freeze: Joi.bool().default(false),
-	decimals: Joi.number().min(1).optional()
+	decimals: Joi.number()
+		.min(1)
+		.optional()
 }).options({ allowUnknown: true })
 
 function createTokenRequest(candidate = {}) {

--- a/app/validators/createTokenRequest.js
+++ b/app/validators/createTokenRequest.js
@@ -18,7 +18,8 @@ const schema = Joi.object({
 		.min(1)
 		.required(),
 	requires_kyc: Joi.bool().default(false),
-	can_freeze: Joi.bool().default(false)
+	can_freeze: Joi.bool().default(false),
+	decimals: Joi.number().min(1).optional()
 }).options({ allowUnknown: true })
 
 function createTokenRequest(candidate = {}) {

--- a/app/validators/sendTokenRequest.js
+++ b/app/validators/sendTokenRequest.js
@@ -4,7 +4,9 @@ const schema = Joi.object({
 	token_id: Joi.string().required(),
 	receiver_id: Joi.string().required(),
 	amount: Joi.number().required(),
-	decimals: Joi.number().min(1).optional()
+	decimals: Joi.number()
+		.min(1)
+		.optional()
 })
 
 function sendTokenRequest(candidate = {}) {

--- a/app/validators/sendTokenRequest.js
+++ b/app/validators/sendTokenRequest.js
@@ -3,7 +3,8 @@ const Joi = require("@hapi/joi")
 const schema = Joi.object({
 	token_id: Joi.string().required(),
 	receiver_id: Joi.string().required(),
-	amount: Joi.number().required()
+	amount: Joi.number().required(),
+	decimals: Joi.number().min(1).optional()
 })
 
 function sendTokenRequest(candidate = {}) {


### PR DESCRIPTION
## Overview

I've meant to add this for a very long time, basically, you can explicitly set the decimals you want to use instead of the defaults that trust enterprises provide.

## Affected Routes

- Creating tokens
- Checking token balances
- Bequesting tokens (permissioned marketplace send)
- Sending Tokens
