### PR TITLE
Batch NFT transfer

### DIFF
--- a/__tests__/e2e/multitransfer_nft_hashgraph.test.js
+++ b/__tests__/e2e/multitransfer_nft_hashgraph.test.js
@@ -1,0 +1,110 @@
+import HashgraphClient from "app/hashgraph/client"
+
+const client = new HashgraphClient()
+
+// NFT is reused for different tests
+let nft
+
+// Account of dummy user claiming NFTs from treasury
+let dummyAccount
+
+// Reused please
+const TOKENS_SUPPLY = 200
+
+// Utility for sending batch.
+const sendBatch = async amount => {
+	if (!dummyAccount || !nft) {
+		throw Error('NFT or account state not initialised.')
+	}
+
+	return await client.multipleNftTransfer({
+		token_id: nft.token_id,
+		receiver_id: dummyAccount.accountId,
+		serials: Array(amount).fill(1).map((e, i) => i + e)
+	})
+}
+
+const sendBatchUsingMirrornode = async (amount = 30) => {
+	if (!dummyAccount || !nft) {
+		throw Error('NFT or account state not initialised.')
+	}
+
+	return await client.batchTransferNft({
+		token_id: nft.token_id,
+		// token_id: '0.0.48905114',
+		receiver_id: dummyAccount.accountId,
+		amount
+	})
+
+}
+
+const mintMoarNfts = async (amount = 10) => {
+	const mintNfts = {
+		amount,
+		token_id: nft.token_id,
+		cid: 'xxx'
+	}
+
+	return await client.mintNonFungibleToken(mintNfts)
+}
+
+// This will be generated uniquely per NFT (low-priority test)
+
+test("This test will create an NFT and mint all tokens", async () => {
+
+	const passTokenData = {
+		supply: TOKENS_SUPPLY,
+		collection_name: 'example nft',
+		symbol: 'te-e2e-nft'
+	}
+
+	nft = await client.createNonFungibleToken(passTokenData)
+
+	const mint = await mintMoarNfts(5)
+
+	expect(mint.token_id).toBe(nft.token_id)
+
+	console.log(mint)
+
+}, 30000)
+
+// Normally this would hit an end point for an integration test
+test("This will create an account and attempt to send a multiple transfer to account", async () => {
+
+	dummyAccount = await client.createAccount()
+
+	// This should fail as we have only minted 5
+	const badSend = await sendBatch(6)
+
+	expect(badSend.total).toBe(0)
+	expect(badSend.error).toBeTruthy()
+
+	const goodSend = await sendBatch(5)
+
+	expect(goodSend.total).toBe(5)
+	expect(goodSend.error).toBeFalsy()
+
+}, 20000)
+
+
+test("Send a big'ol batch of NFTs!", async () => {
+
+	const send = await sendBatchUsingMirrornode()
+
+	expect(send.error[0]).toBe(`The treasury does not hold the amount of NFTs of id ${nft.token_id} to do the required batch transfer`)
+
+	// Due to mirrornode limitations we can't test this in real time
+	// await mintMoarNfts()
+	// await mintMoarNfts()
+	// await mintMoarNfts()
+	// await mintMoarNfts()
+	// await mintMoarNfts()
+	// await mintMoarNfts()
+	// await mintMoarNfts()
+	//
+	// const sendMoar = await sendBatchUsingMirrornode(38)
+	//
+	// console.log(sendMoar)
+	// expect(sendMoar.results.length).toBeTruthy()
+
+}, 20000)

--- a/app/handler/batchTransferNftHandler.js
+++ b/app/handler/batchTransferNftHandler.js
@@ -1,0 +1,34 @@
+import Response from "app/response"
+import transferNftRequest from "app/validators/transferNftRequest"
+import batchTransferNftRequest from "../validators/batchTransferNftRequest"
+
+async function BatchTransferNftHandler(req, res) {
+	const validationErrors = batchTransferNftRequest(req.body)
+
+	if (validationErrors) {
+		return Response.unprocessibleEntity(res, validationErrors)
+	}
+
+	const { receiver_id, token_id, amount } = req.body
+
+	const batchTransferPayload = {
+		receiver_id,
+		token_id,
+		amount
+	}
+
+	const { hashgraphClient } = req.context
+	const sendResponse = await hashgraphClient.batchTransferNft(batchTransferPayload)
+
+	if (sendResponse.error) {
+		return Response.unprocessibleEntity(res, sendResponse.error)
+	}
+
+	if (sendResponse) {
+		return Response.json(res, sendResponse)
+	}
+
+	return Response.badRequest(res)
+}
+
+export default BatchTransferNftHandler

--- a/app/handler/batchTransferNftHandler.js
+++ b/app/handler/batchTransferNftHandler.js
@@ -18,7 +18,9 @@ async function BatchTransferNftHandler(req, res) {
 	}
 
 	const { hashgraphClient } = req.context
-	const sendResponse = await hashgraphClient.batchTransferNft(batchTransferPayload)
+	const sendResponse = await hashgraphClient.batchTransferNft(
+		batchTransferPayload
+	)
 
 	if (sendResponse.error) {
 		return Response.unprocessibleEntity(res, sendResponse.error)

--- a/app/hashgraph/client.js
+++ b/app/hashgraph/client.js
@@ -694,12 +694,7 @@ class HashgraphClient extends HashgraphClientContract {
 	 * @param ser
 	 * @returns {Promise<void>}
 	 */
-	multipleNftTransfer = async ({
-		token_id,
-		receiver_id,
-		serials
-	}) => {
-
+	multipleNftTransfer = async ({ token_id, receiver_id, serials }) => {
 		const client = this.#client
 
 		const transfer = await new TransferTransaction()
@@ -755,7 +750,11 @@ class HashgraphClient extends HashgraphClientContract {
 
 		// Required recur fn needed for pagination
 		const sendNftTransaction = async (limit, paginationLink) => {
-			const nfts = await Mirror.fetchNftIdsForBatchTransfer(token_id, limit, paginationLink)
+			const nfts = await Mirror.fetchNftIdsForBatchTransfer(
+				token_id,
+				limit,
+				paginationLink
+			)
 
 			const transfer = await this.multipleNftTransfer({
 				token_id,
@@ -770,7 +769,6 @@ class HashgraphClient extends HashgraphClientContract {
 		}
 
 		const cycleBatchTransfers = async (cycle, results = [], paginationLink) => {
-
 			if (!cycle.length) {
 				return results
 			}

--- a/app/hashgraph/client.js
+++ b/app/hashgraph/client.js
@@ -30,6 +30,7 @@ import Explorer from "app/utils/explorer"
 import sendWebhookMessage from "app/utils/sendWebhookMessage"
 import Mirror from "app/utils/mirrornode"
 import Specification from "app/hashgraph/tokens/specifications"
+import Batchable from "app/utils/batchable"
 
 class HashgraphClient extends HashgraphClientContract {
 	// Keep a private internal reference to SDK client
@@ -681,6 +682,122 @@ class HashgraphClient extends HashgraphClientContract {
 					"Transfer failed, ensure that the recipient account is valid and has associated to the token"
 				]
 			}
+		}
+	}
+
+	/**
+	 * Given a token id and a receiver, attempt to send tokens based on limit
+	 * return status of transfer.
+	 *
+	 * @param token_id
+	 * @param receiver_id
+	 * @param ser
+	 * @returns {Promise<void>}
+	 */
+	multipleNftTransfer = async ({
+		token_id,
+		receiver_id,
+		serials
+	}) => {
+
+		const client = this.#client
+
+		const transfer = await new TransferTransaction()
+
+		serials.map(serial => {
+			transfer.addNftTransfer(
+				new NftId(token_id, serial),
+				Config.accountId,
+				receiver_id
+			)
+		})
+
+		// We are making the assumption that if the transaction is successful NFTs are sent
+		try {
+			const tx = await transfer.execute(client)
+
+			await tx.getReceipt(client)
+
+			return {
+				serials,
+				total: serials.length
+			}
+		} catch (e) {
+			return {
+				error: e.message.toString(),
+				total: 0
+			}
+		}
+	}
+
+	/**
+	 * Attempt to transfer a batch of NFTs, of a particular amount
+	 *
+	 * We check that
+	 *
+	 * @param token_id
+	 * @param receiver_id
+	 * @param amount
+	 * @returns {Promise<{error: string}|{transaction_id: string, amount: (number|*), receiver_id}>}
+	 */
+	batchTransferNft = async ({ token_id, receiver_id, amount }) => {
+		const hasNft = await Mirror.checkTreasuryHasNftAmount(token_id, amount)
+
+		if (!hasNft) {
+			return {
+				errors: [
+					`The treasury does not hold the amount of NFTs of id ${token_id} to do the required batch transfer`
+				]
+			}
+		}
+
+		const transferCycleLimits = Batchable.nftTransfer(amount)
+
+		// Required recur fn needed for pagination
+		const sendNftTransaction = async (limit, paginationLink) => {
+			const nfts = await Mirror.fetchNftIdsForBatchTransfer(token_id, limit, paginationLink)
+
+			const transfer = await this.multipleNftTransfer({
+				token_id,
+				receiver_id,
+				serials: nfts.serials
+			})
+
+			return {
+				...nfts,
+				...transfer
+			}
+		}
+
+		const cycleBatchTransfers = async (cycle, results = [], paginationLink) => {
+
+			if (!cycle.length) {
+				return results
+			}
+
+			const limit = cycle.shift()
+
+			const transfer = await sendNftTransaction(limit, paginationLink)
+
+			results.push(transfer)
+
+			return cycleBatchTransfers(cycle, results, transfer.link)
+		}
+
+		const results = await cycleBatchTransfers(transferCycleLimits)
+
+		const errors = results.map(e => e.errors).filter(e => e)
+
+		if (errors.length) {
+			return {
+				errors
+			}
+		}
+
+		return {
+			results,
+			expected: amount,
+			actual_sent: results.map(e => e.total).reduce((e, n) => e + n)
 		}
 	}
 }

--- a/app/utils/batchable.js
+++ b/app/utils/batchable.js
@@ -1,4 +1,3 @@
-
 const BATCH_LIMITS = {
 	nftTransfers: 10
 }
@@ -10,15 +9,17 @@ const BATCH_LIMITS = {
  * @returns {any[]}
  */
 function nftTransfer(amount) {
-
 	// mod rem diff
 	const rem = amount % BATCH_LIMITS.nftTransfers
 
 	// Basal cycle for batch, as a whole number
 	const max = (amount - rem) / BATCH_LIMITS.nftTransfers
 
-		// When rem is falsely, remove -- more simple then if
-	const cycle = Array(max).fill(BATCH_LIMITS.nftTransfers).concat(rem).filter(e => e)
+	// When rem is falsely, remove -- more simple then if
+	const cycle = Array(max)
+		.fill(BATCH_LIMITS.nftTransfers)
+		.concat(rem)
+		.filter(e => e)
 
 	// For readability
 	return cycle

--- a/app/utils/batchable.js
+++ b/app/utils/batchable.js
@@ -1,0 +1,29 @@
+
+const BATCH_LIMITS = {
+	nftTransfers: 10
+}
+
+/**
+ * Create an array of cycles of NFT transfers based on an amount and a max limit.
+ *
+ * @param amount
+ * @returns {any[]}
+ */
+function nftTransfer(amount) {
+
+	// mod rem diff
+	const rem = amount % BATCH_LIMITS.nftTransfers
+
+	// Basal cycle for batch, as a whole number
+	const max = (amount - rem) / BATCH_LIMITS.nftTransfers
+
+		// When rem is falsely, remove -- more simple then if
+	const cycle = Array(max).fill(BATCH_LIMITS.nftTransfers).concat(rem).filter(e => e)
+
+	// For readability
+	return cycle
+}
+
+export default {
+	nftTransfer
+}

--- a/app/utils/mirrornode.js
+++ b/app/utils/mirrornode.js
@@ -10,9 +10,11 @@ const queryNftAccountOwner = (token_id, serial) =>
 	`${mirrornode}/api/v1/tokens/${token_id}/nfts/${serial}`
 const queryNftForOwner = (token_id, account_id) =>
 	`${mirrornode}/api/v1/tokens/${token_id}/nfts/?account.id=${account_id}`
-const queryTreasuryTokenBalance = (token_id, account_id) => `${mirrornode}/api/v1/tokens/${token_id}/balances/?account.id=${account_id}`
-const getNftByLimit = (token_id, account_id, limit = 20) => `${mirrornode}/api/v1/tokens/${token_id}/nfts?account.id=${account_id}&order=asc&limit=${limit}`
-const queryReq = (next) => `${mirrornode}${next}`
+const queryTreasuryTokenBalance = (token_id, account_id) =>
+	`${mirrornode}/api/v1/tokens/${token_id}/balances/?account.id=${account_id}`
+const getNftByLimit = (token_id, account_id, limit = 20) =>
+	`${mirrornode}/api/v1/tokens/${token_id}/nfts?account.id=${account_id}&order=asc&limit=${limit}`
+const queryReq = next => `${mirrornode}${next}`
 
 const MIRRORNODE_WAIT_MS = 500
 const MIRRORNODE_TRIES = 5
@@ -99,9 +101,7 @@ async function checkTreasuryHasNftAmount(
 		queryTreasuryTokenBalance(nft_id, expected)
 	)
 
-	const {
-		balances
-	} = result.data
+	const { balances } = result.data
 
 	if (!balances.length) {
 		return false
@@ -109,7 +109,6 @@ async function checkTreasuryHasNftAmount(
 
 	return balances[0].balance >= amount
 }
-
 
 /**
  * Fetch the nft ids for a particular NFT tx, include the "next" id
@@ -130,10 +129,7 @@ async function fetchNftIdsForBatchTransfer(
 		link ? queryReq(link) : getNftByLimit(nft_id, expected, limit)
 	)
 
-	const {
-		nfts,
-		links
-	} = result.data
+	const { nfts, links } = result.data
 
 	const serials = nfts.splice(0, limit)
 

--- a/app/validators/batchTransferNftRequest.js
+++ b/app/validators/batchTransferNftRequest.js
@@ -1,0 +1,17 @@
+const Joi = require("@hapi/joi")
+
+const schema = Joi.object({
+	token_id: Joi.string().required(),
+	receiver_id: Joi.string().required(),
+	amount: Joi.number().required()
+})
+
+function batchTransferNftRequest(candidate = {}) {
+	const validation = schema.validate(candidate || {})
+
+	if (validation.error) {
+		return validation.error.details.map(error => error.message)
+	}
+}
+
+export default batchTransferNftRequest

--- a/pages/api/nft/batch.js
+++ b/pages/api/nft/batch.js
@@ -1,0 +1,15 @@
+import onlyPost from "app/middleware/onlyPost"
+import withAuthentication from "app/middleware/withAuthentication"
+import useHashgraphContext from "app/context/useHashgraphContext"
+import prepare from "app/utils/prepare"
+import ensureEncryptionKey from "app/middleware/ensureEncryptionKey"
+import batchTransferNftHandler from "app/handler/batchTransferNftHandler"
+import ensureMirrornodeSet from "app/middleware/ensureMirrornodeSet"
+
+export default prepare(
+	onlyPost,
+	ensureEncryptionKey,
+	ensureMirrornodeSet,
+	withAuthentication,
+	useHashgraphContext
+)(batchTransferNftHandler)


### PR DESCRIPTION
## Overview

Adds a new "batch" NFT route to the API, it'll do a best effort to send all NFTs to the receiver or it'll send back a list of errors.

Recommend server-like deployments instead of functions/serverless deployment (due to serverless timeout issues), digital ocean app platform is a good PaaS to use.